### PR TITLE
Avoid boxing

### DIFF
--- a/Interpreter.cs
+++ b/Interpreter.cs
@@ -160,16 +160,7 @@ public static class Interpreter
 
     private static RunTimeResult Visit_Number(NumberNode node, Context context)
     {
-        double value;
-        if (node.tok.Value is null)
-        {
-            value = 0;
-        }
-        else
-        {
-            value = Convert.ToDouble(node.tok.Value);
-        }
-        return new RunTimeResult().Success(new VNumber(value).SetContext(context).SetPos(node.StartPos, node.EndPos));
+        return new RunTimeResult().Success(new VNumber(node.tok.Value).SetContext(context).SetPos(node.StartPos, node.EndPos));
     }
     private static RunTimeResult Visit_String(StringNode node, Context context)
     {
@@ -609,12 +600,8 @@ public static class Interpreter
         List<string> argNames = new(node.argNameToks.Count);
         for (int i = 0; i < node.argNameToks.Count; i++)
         {
-            Token tok = node.argNameToks[i];
-            string? name = (string?)tok.Value;
-            if (name is not null)
-            {
-                argNames.Add(name);
-            }
+            Token<string> tok = (Token<string>)node.argNameToks[i];
+            argNames.Add(tok.Value);
         }
 
         VFunction funcValue = new(funcName, bodyNode, argNames, node.retNull);

--- a/Lexer.cs
+++ b/Lexer.cs
@@ -25,7 +25,7 @@ public class Lexer
     }
 
     // this is used to make a number token of type int or float
-    private (Token, Error) MakeNumber()
+    private (Token<double>, Error) MakeNumber()
     {
         StringBuilder stringBuilder = new();
         bool hasDot = false;
@@ -55,17 +55,9 @@ public class Lexer
             }
             Advance();
         }
-
-        if (hasDot)
-        {
-            return (new Token(TokenType.FLOAT, double.Parse(stringBuilder.ToString()), posStart, pos), ErrorNull.Instance);
-        }
-        else
-        {
-            return (new Token(TokenType.INT, int.Parse(stringBuilder.ToString()), posStart, pos), ErrorNull.Instance);
-        }
+        return (new Token<double>(TokenType.FLOAT, double.Parse(stringBuilder.ToString()), posStart, pos), ErrorNull.Instance);
     }
-    private Token MakeIdentifier()
+    private Token<string> MakeIdentifier()
     {
         StringBuilder stringBuilder = new();
         Position posStart = pos;
@@ -79,14 +71,14 @@ public class Lexer
         string idStr = stringBuilder.ToString();
         if (TokenTypeHelper.IsKeyword(idStr))
         {
-            return new Token(TokenType.KEYWORD, idStr, posStart, pos);
+            return new Token<string>(TokenType.KEYWORD, idStr, posStart, pos);
         }
         else
         {
-            return new Token(TokenType.IDENTIFIER, idStr, posStart, pos);
+            return new Token<string>(TokenType.IDENTIFIER, idStr, posStart, pos);
         }
     }
-    private (Token, Error) MakeNotEquals()
+    private (Token<TokenNoValueType>, Error) MakeNotEquals()
     {
         Position posStart = pos;
         Advance();
@@ -94,12 +86,12 @@ public class Lexer
         if (current_char == '=')
         {
             Advance();
-            return (new Token(TokenType.NE, startPos: posStart, endPos: pos), ErrorNull.Instance);
+            return (new Token<TokenNoValueType>(TokenType.NE, startPos: posStart, endPos: pos), ErrorNull.Instance);
         }
         Advance();
-        return (new Token(TokenType.NULL), new ExpectedCharError(posStart, "Expected '=' after '!'"));
+        return (new Token<TokenNoValueType>(TokenType.NULL), new ExpectedCharError(posStart, "Expected '=' after '!'"));
     }
-    private Token MakeDecicion(char checkChar, TokenType TTTrue, TokenType TTFalse)
+    private Token<TokenNoValueType> MakeDecicion(char checkChar, TokenType TTTrue, TokenType TTFalse)
     {
         Position posStart = pos;
         Advance();
@@ -107,11 +99,11 @@ public class Lexer
         if (current_char == checkChar)
         {
             Advance();
-            return new Token(TTTrue, startPos: posStart, endPos: pos);
+            return new Token<TokenNoValueType>(TTTrue, startPos: posStart, endPos: pos);
         }
-        return new Token(TTFalse, startPos: posStart, endPos: pos);
+        return new Token<TokenNoValueType>(TTFalse, startPos: posStart, endPos: pos);
     }
-    private Token MakeString()
+    private Token<string> MakeString()
     {
         string value = string.Empty;
         Position startPos = pos;
@@ -151,7 +143,7 @@ public class Lexer
             Advance();
         }
         Advance();
-        return new Token(TokenType.STRING, value, startPos, pos);
+        return new Token<string>(TokenType.STRING, value, startPos, pos);
     }
     private void SkipComent()
     {
@@ -162,7 +154,7 @@ public class Lexer
         }
         Advance();
     }
-    private Token SkipTypeAnotation()
+    private Token<TokenNoValueType> SkipTypeAnotation()
     {
         Advance();
         while (current_char is not '=' and not char.MaxValue)
@@ -170,45 +162,45 @@ public class Lexer
             Advance();
         }
         Advance();
-        return new Token(TokenType.EQ, pos, Position.Null, Position.Null);
+        return new Token<TokenNoValueType>(TokenType.EQ, pos, Position.Null);
     }
 
-    private Token MakePlus(){
+    private Token<TokenNoValueType> MakePlus(){
         Position startPos = pos;
         Advance();
 
         if(current_char == '+'){ // it is ++
             Advance();
-            return new Token(TokenType.PP, startPos, pos);
+            return new Token<TokenNoValueType>(TokenType.PP, startPos, pos);
         }
         if(current_char == '='){ // its +=
             Advance();
-            return new Token(TokenType.PLEQ, startPos, pos);
+            return new Token<TokenNoValueType>(TokenType.PLEQ, startPos, pos);
         }
-        return new Token(TokenType.PLUS, startPos, pos);
+        return new Token<TokenNoValueType>(TokenType.PLUS, startPos, pos);
     }
-    private Token MakeMinus(){
+    private Token<TokenNoValueType> MakeMinus(){
         Position startPos = pos;
         Advance();
 
         if(current_char == '-'){ // it is --
             Advance();
-            return new Token(TokenType.MM, startPos, pos);
+            return new Token<TokenNoValueType>(TokenType.MM, startPos, pos);
         }
         if(current_char == '='){ // its -=
             Advance();
-            return new Token(TokenType.MIEQ, startPos, pos);
+            return new Token<TokenNoValueType>(TokenType.MIEQ, startPos, pos);
         }
         if (current_char == '>'){
             Advance();
-            return new Token(TokenType.ARROW, startPos, pos);
+            return new Token<TokenNoValueType>(TokenType.ARROW, startPos, pos);
         }
-        return new Token(TokenType.MINUS, startPos, pos);
+        return new Token<TokenNoValueType>(TokenType.MINUS, startPos, pos);
     }
     // generates all tokens
-    public (List<Token>, Error) MakeTokens()
+    public (List<IToken>, Error) MakeTokens()
     {
-        List<Token> tokens = [];
+        List<IToken> tokens = [];
         int parenthesesCount = 0; // to check if there are unclosed parentesies
         int squarBracketCount = 0; // to check if there are unclosed square brackets
 
@@ -229,17 +221,17 @@ public class Lexer
             }
             else if (current_char is ';' or '\n' or '\r')
             {
-                tokens.Add(new Token(TokenType.NEWLINE, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.NEWLINE, pos, Position.Null));
                 Advance();
             }
             else if (current_char == '.')
             {
-                tokens.Add(new Token(TokenType.DOT, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.DOT, pos, Position.Null));
                 Advance();
             }
             else if (char.IsDigit(current_char)) // Check for digits (int)
             {
-                (Token, Error) res = MakeNumber();
+                (Token<double>, Error) res = MakeNumber();
                 if(res.Item2.IsError){
                     return ([], res.Item2);
                 }
@@ -272,25 +264,25 @@ public class Lexer
             }
             else if (current_char == '^')
             {
-                tokens.Add(new Token(TokenType.POW, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.POW, pos, Position.Null));
                 Advance();
             }
             else if (current_char == '(')
             {
                 parenthesesCount++;
-                tokens.Add(new Token(TokenType.LPAREN, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.LPAREN, pos, Position.Null));
                 Advance();
             }
             else if (current_char == ')')
             {
                 parenthesesCount--;
-                tokens.Add(new Token(TokenType.RPAREN, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.RPAREN, pos, Position.Null));
                 Advance();
             }
             // Comparison
             else if (current_char == '!')
             {
-                (Token, Error) res = MakeNotEquals();
+                (Token<TokenNoValueType>, Error) res = MakeNotEquals();
                 if (res.Item2.IsError)
                 {
                     return ([], res.Item2);
@@ -312,19 +304,19 @@ public class Lexer
             // Other
             else if (current_char == ',')
             {
-                tokens.Add(new Token(TokenType.COMMA, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.COMMA, pos, Position.Null));
                 Advance();
             }
             else if (current_char == '[')
             {
                 squarBracketCount++;
-                tokens.Add(new Token(TokenType.LSQUARE, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.LSQUARE, pos, Position.Null));
                 Advance();
             }
             else if (current_char == ']')
             {
                 squarBracketCount--;
-                tokens.Add(new Token(TokenType.RSQUARE, string.Empty, pos, Position.Null));
+                tokens.Add(new Token<TokenNoValueType>(TokenType.RSQUARE, pos, Position.Null));
                 Advance();
             }
             else
@@ -333,7 +325,7 @@ public class Lexer
                 char invalidChar = current_char;
                 Position posStart = pos;
                 Advance();
-                return (new List<Token>(), new IllegalCharError(posStart, "Invalid char: " + invalidChar.ToString()));
+                return (new List<IToken>(), new IllegalCharError(posStart, "Invalid char: " + invalidChar.ToString()));
             }
         }
         if(parenthesesCount != 0){
@@ -343,7 +335,7 @@ public class Lexer
             return ([], new UnclosedBracketsError(Position.Null, "There are more or less Open square brackets than closed ones"));
         }
 
-        tokens.Add(new Token(TokenType.EOF, string.Empty, pos, Position.Null)); // Add the End Of File token
+        tokens.Add(new Token<TokenNoValueType>(TokenType.EOF, pos, Position.Null)); // Add the End Of File token
         return (tokens, ErrorNull.Instance);
     }
 

--- a/Main.cs
+++ b/Main.cs
@@ -62,7 +62,7 @@ internal  class RunClass
     {
         // create a Lexer and generate the tokens with it
         Lexer lexer = new(text, fn);
-        (List<Token>, Error) tokens = lexer.MakeTokens();
+        (List<IToken>, Error) tokens = lexer.MakeTokens();
 
         // look if the lexer threw an Error
         if (tokens.Item2.IsError)
@@ -109,7 +109,7 @@ internal  class RunClass
 
         // 2: create tokens
         sw.Restart();
-        (List<Token>, Error) tokens = lexer.MakeTokens();
+        (List<IToken>, Error) tokens = lexer.MakeTokens();
 
         if (tokens.Item2.IsError)
         {

--- a/Node Scripts/Node.cs
+++ b/Node Scripts/Node.cs
@@ -17,9 +17,9 @@ public class NodeNull : INode
     private NodeNull() { }
 }
 // NumberNode implements INode
-public class NumberNode(Token tok) : INode
+public class NumberNode(Token<double> tok) : INode
 {
-    public readonly Token tok = tok;
+    public readonly Token<double> tok = tok;
 
     // Implement properties, not fields
     public Position StartPos { get; set; } = tok.StartPos;
@@ -30,9 +30,9 @@ public class NumberNode(Token tok) : INode
 
 
 // This node represents a string token
-public class StringNode(Token tok) : INode
+public class StringNode(Token<string> tok) : INode
 {
-    public readonly Token tok = tok;
+    public readonly Token<string> tok = tok;
 
     public Position StartPos { get; set; } = tok.StartPos;
     public Position EndPos { get; set; } = tok.EndPos;
@@ -55,10 +55,10 @@ public class ListNode(List<INode> elementNodes, Position posStart, Position posE
 }
 
 // This node represents a binary operation
-public class BinOpNode(INode leftNode, Token opTok, INode rightNode) : INode
+public class BinOpNode(INode leftNode, IToken opTok, INode rightNode) : INode
 {
     public readonly INode leftNode = leftNode;
-    public readonly Token opTok = opTok;
+    public readonly IToken opTok = opTok;
     public readonly INode rightNode = rightNode;
 
     public Position StartPos { get; set; } = leftNode.StartPos;
@@ -68,9 +68,9 @@ public class BinOpNode(INode leftNode, Token opTok, INode rightNode) : INode
 }
 
 // This node represents a unary operation
-public class UnaryOpNode(Token opTok, INode node) : INode
+public class UnaryOpNode(IToken opTok, INode node) : INode
 {
-    public readonly Token opTok = opTok;
+    public readonly IToken opTok = opTok;
     public readonly INode node = node;
 
     public Position StartPos { get; set; } = opTok.StartPos;
@@ -80,9 +80,9 @@ public class UnaryOpNode(Token opTok, INode node) : INode
 }
 
 // This node represents a variable access
-public class VarAccessNode(Token varNameTok) : INode
+public class VarAccessNode(Token<string> varNameTok) : INode
 {
-    public readonly Token varNameTok = varNameTok;
+    public readonly Token<string> varNameTok = varNameTok;
     public bool fromCall = false;
 
     public Position StartPos { get; set; } = varNameTok.StartPos;
@@ -95,9 +95,9 @@ public class VarAccessNode(Token varNameTok) : INode
 }
 
 // This node represents a variable assignment
-public class VarAssignNode(Token varNameTok, INode valueNode) : INode
+public class VarAssignNode(Token<string> varNameTok, INode valueNode) : INode
 {
-    public readonly Token varNameTok = varNameTok;
+    public readonly Token<string> varNameTok = varNameTok;
     public readonly INode valueNode = valueNode;
 
     public Position StartPos { get; set; } = varNameTok.StartPos;
@@ -110,9 +110,9 @@ public class VarAssignNode(Token varNameTok, INode valueNode) : INode
 }
 
 // This node represents a dot (.) variable access
-public class DotVarAccessNode(Token varNameTok, INode parent) : INode
+public class DotVarAccessNode(Token<string> varNameTok, INode parent) : INode
 {
-    public readonly Token varNameTok = varNameTok;
+    public readonly Token<string> varNameTok = varNameTok;
     public readonly INode parent = parent;
 
     public Position StartPos { get; set; } = varNameTok.StartPos;
@@ -120,9 +120,9 @@ public class DotVarAccessNode(Token varNameTok, INode parent) : INode
 }
 
 // This node represents a function call using dot notation
-public class DotCallNode(Token funcNameTok, List<INode> argNodes, INode parent) : INode
+public class DotCallNode(Token<string> funcNameTok, List<INode> argNodes, INode parent) : INode
 {
-    public readonly Token funcNameTok = funcNameTok;
+    public readonly Token<string> funcNameTok = funcNameTok;
     public readonly ImmutableList<INode> argNodes = argNodes.ToImmutableList();
     public readonly INode parent = parent;
 
@@ -141,9 +141,9 @@ public class IfNode(List<IfExpresionCases> cases, ElseCaseData elseCase) : INode
 }
 
 // This node represents a for loop
-public class ForNode(Token varNameTok, INode startValueNode, INode endValueNode, INode? stepValueNode, INode bodyNode, bool retNull) : INode
+public class ForNode(Token<string> varNameTok, INode startValueNode, INode endValueNode, INode? stepValueNode, INode bodyNode, bool retNull) : INode
 {
-    public readonly Token varNameTok = varNameTok;
+    public readonly Token<string> varNameTok = varNameTok;
     public readonly INode startValueNode = startValueNode;
     public readonly INode endValueNode = endValueNode;
     public readonly INode? stepValueNode = stepValueNode;
@@ -168,12 +168,12 @@ public class WhileNode(INode conditionNode, INode bodyNode, bool retNull) : INod
 // This node represents a function definition
 public class FuncDefNode : INode
 {
-    public readonly Token? varNameTok;
-    public readonly ImmutableList<Token> argNameToks;
+    public readonly Token<string> varNameTok;
+    public readonly ImmutableList<IToken> argNameToks;
     public readonly INode bodyNode;
     public readonly bool retNull;
 
-    public FuncDefNode(Token? varNameTok, List<Token> argNameToks, INode bodyNode, bool autoReturn)
+    public FuncDefNode(Token<string> varNameTok, List<IToken> argNameToks, INode bodyNode, bool autoReturn)
     {
         this.varNameTok = varNameTok;
         this.argNameToks = (argNameToks ?? []).ToImmutableList();
@@ -237,11 +237,11 @@ public class BreakNode(Position startPos, Position endPos) : INode
     public Position EndPos { get; set; } = endPos;
 }
 
-public class TryCatchNode(INode tryNode, INode catchNode, Token? catchVarName) : INode
+public class TryCatchNode(INode tryNode, INode catchNode, Token<string> catchVarName) : INode
 {
     public readonly INode TryNode = tryNode;
     public readonly INode CatchNode = catchNode;
-    public readonly Token? ChatchVarName = catchVarName;
+    public readonly Token<string> ChatchVarName = catchVarName;
 
     public Position StartPos { get; set; } = tryNode.StartPos;
     public Position EndPos { get; set; } = catchNode is NodeNull _ ? tryNode.EndPos : catchNode.EndPos;

--- a/Other Data Classes/Token.cs
+++ b/Other Data Classes/Token.cs
@@ -58,17 +58,27 @@ public static class TokenTypeHelper
 
     public static bool IsKeyword(string s) => Keywords.Contains(s);
 }
+public interface IToken{
+    TokenType Type { get; }
+    Position StartPos { get; }
+    Position EndPos { get; }
+    public bool Matches(TokenType type, string value){
+        return false;
+    }
+}
+
 
 // Token class optimized with enum and nullable reference types
-public class Token
+public class Token<T> : IToken
 {
-    public readonly TokenType Type;
-    public readonly object Value;
-    public readonly Position StartPos;
-    public readonly Position EndPos;
+    public TokenType Type { get; }
+    public  T Value { get; }
+    public Position StartPos { get; }
+    public Position EndPos { get; }
+
 
     // Constructor
-    public Token(TokenType type, object value, Position startPos, Position endPos)
+    public Token(TokenType type, T value, Position startPos, Position endPos)
     {
         Type = type;
         Value = value;
@@ -85,28 +95,8 @@ public class Token
             EndPos = endPos;
         }
     }
-    public Token(TokenType type, Position startPos, Position endPos)
-    {
-        Type = type;
-        Value = "";
-
-        if (!startPos.IsNull)
-        {
-            StartPos = startPos;
-            EndPos = StartPos; // If there is no end Position just assume it to be 1 char
-            EndPos.Advance(' ');
-        }
-
-        if (!endPos.IsNull)
-        {
-            EndPos = endPos;
-        }
-    }
-    public Token(TokenType type)
-    {
-        Type = type;
-        Value = "";
-    }
+    public Token(TokenType type, Position startPos, Position endPos) : this(type, default(T), startPos, endPos){}
+    public Token(TokenType type) : this(type, default(T), Position.Null, Position.Null){}
 
     // String Representation
     public override string ToString()
@@ -121,4 +111,9 @@ public class Token
         }
         return Type == type && (Value as string) == value;
     }
+}
+
+public class TokenNoValueType{
+    public static TokenNoValueType Instance = new();
+    private TokenNoValueType(){}
 }

--- a/Parser.cs
+++ b/Parser.cs
@@ -88,15 +88,15 @@ public class ParseResult
 // the parser which is used to make the abstract syntax tree
 public class Parser
 {
-    private readonly List<Token> tokens;
+    private readonly List<IToken> tokens;
     private int tokIndex = -1;
-    private Token currentToken;
+    private IToken currentToken;
 
     // initalizer
-    public Parser(List<Token> tokens)
+    public Parser(List<IToken> tokens)
     {
         this.tokens = tokens;
-        currentToken = new Token(TokenType.NULL);
+        currentToken = new Token<TokenNoValueType>(TokenType.NULL);
         Advance();
     }
     // goes to the next token
@@ -107,7 +107,7 @@ public class Parser
         return 0; // tutorial sayd wrap in advance so it needs to return something
     }
 
-    private Token Reverse(int amount = 1)
+    private IToken Reverse(int amount = 1)
     {
         tokIndex -= amount;
         UpdateCurrentTok();
@@ -292,7 +292,7 @@ public class Parser
             return res.Failure(new ExpectedTokenError(currentToken.StartPos, "Expected identifier"));
         }
 
-        Token varName = currentToken;
+        Token<string> varName = (Token<string>)currentToken;
         res.Register(Advance());
 
         if (currentToken.Type != TokenType.EQ)
@@ -466,12 +466,12 @@ public class Parser
     private ParseResult IdentifierExpr()
     {
         ParseResult res = new();
-        Token tok = currentToken;
+        IToken tok = currentToken;
 
         res.Register(Advance());
         if (currentToken.Type != TokenType.DOT) // normal identifier
         {
-            return res.Success(new VarAccessNode(tok));
+            return res.Success(new VarAccessNode((Token<string>)tok));
         }
 
         // there is a dot notaited identifier
@@ -481,12 +481,12 @@ public class Parser
             return res.Failure(new ExpectedTokenError(currentToken.StartPos, "Expected IDENTIFIER"));
         }
 
-        Token varName = currentToken;
+        Token<string> varName = (Token<string>)currentToken;
 
         res.Register(Advance());
         if (currentToken.Type != TokenType.LPAREN) // it is a variable
         {
-            return res.Success(new DotVarAccessNode(varName, new VarAccessNode(tok)));
+            return res.Success(new DotVarAccessNode(varName, new VarAccessNode((Token<string>)tok)));
         }
 
         // it is a function
@@ -496,7 +496,7 @@ public class Parser
         {
             return res;
         }
-        return res.Success(new DotCallNode(varName, args.Item2, new VarAccessNode(tok)));
+        return res.Success(new DotCallNode(varName, args.Item2, new VarAccessNode((Token<string>)tok)));
     }
     private ParseResult FuncDef()
     {
@@ -508,10 +508,10 @@ public class Parser
 
         res.Register(Advance());
 
-        Token? varNameTok;
+        Token<string> varNameTok;
         if (currentToken.Type == TokenType.IDENTIFIER)
         {
-            varNameTok = currentToken;
+            varNameTok = (Token<string>)currentToken;
             res.Register(Advance());
             if (currentToken.Type != TokenType.LPAREN)
             {
@@ -520,7 +520,7 @@ public class Parser
         }
         else
         {
-            varNameTok = null;
+            varNameTok = new Token<string>(TokenType.NULL);
             if (currentToken.Type != TokenType.LPAREN)
             {
                 return res.Failure(new ExpectedTokenError(currentToken.StartPos, "expected identifier or '('"));
@@ -528,7 +528,7 @@ public class Parser
         }
 
         res.Register(Advance());
-        List<Token> argNameTok = [];
+        List<IToken> argNameTok = [];
 
         if (currentToken.Type == TokenType.IDENTIFIER)
         { // has args
@@ -638,7 +638,7 @@ public class Parser
 
         return (res.Success(NodeNull.Instance), argNodes); // empty node just for the parseresult.succses
     }
-    private ParseResult ShortendVarAssignHelper(Token varName, TokenType type){
+    private ParseResult ShortendVarAssignHelper(Token<string> varName, TokenType type){
         ParseResult res = new();
 
         res.Register(Advance());
@@ -649,7 +649,7 @@ public class Parser
         }
 
         // This converts varName += Expr to varName = varName + Expr 
-        INode converted = new BinOpNode(new VarAccessNode(varName), new Token(type, expr.StartPos, expr.StartPos), expr);
+        INode converted = new BinOpNode(new VarAccessNode(varName), new Token<TokenNoValueType>(type, expr.StartPos, expr.StartPos), expr);
         return res.Success(new VarAssignNode(varName, converted));
     }
     private ParseResult VarAssignExpr()
@@ -667,7 +667,7 @@ public class Parser
             return res.Failure(new InvalidSyntaxError(currentToken.StartPos, "Expected Identifier"));
         }
 
-        Token varName = currentToken;
+        Token<string> varName = (Token<string>)currentToken;
         INode expr;
 
         res.Register(Advance());
@@ -697,8 +697,8 @@ public class Parser
                     varName,
                     new BinOpNode(
                         new VarAccessNode(varName),
-                        new Token(TokenType.PLUS),
-                        new NumberNode(new Token(TokenType.INT, 1, Position.Null, Position.Null))
+                        new Token<TokenNoValueType>(TokenType.PLUS),
+                        new NumberNode(new Token<double>(TokenType.INT, 1, Position.Null, Position.Null))
                     )
                 )
             );
@@ -709,8 +709,8 @@ public class Parser
                     varName,
                     new BinOpNode(
                         new VarAccessNode(varName),
-                        new Token(TokenType.MINUS),
-                        new NumberNode(new Token(TokenType.INT, 1, Position.Null, Position.Null))
+                        new Token<TokenNoValueType>(TokenType.MINUS),
+                        new NumberNode(new Token<double>(TokenType.INT, 1, Position.Null, Position.Null))
                     )
                 )
             );
@@ -743,7 +743,7 @@ public class Parser
 
         INode tryBlock = res.Register(Statements());
         INode catchBlock = NodeNull.Instance;
-        Token? varName = null;
+        Token<string> varName = new Token<string>(TokenType.NULL);
         if (res.HasError)
         {
             return res;
@@ -764,7 +764,7 @@ public class Parser
             res.Register(Advance());
 
             if(currentToken.Type == TokenType.IDENTIFIER){
-                varName = currentToken;
+                varName = (Token<string>)currentToken;
                 res.Register(Advance());
             }
 
@@ -789,18 +789,18 @@ public class Parser
     {
         ParseResult res = new();
 
-        Token tok = currentToken;
+        IToken tok = currentToken;
 
         // check tyoes
         if (tok.Type is TokenType.INT or TokenType.FLOAT)
         {
             res.Register(Advance());
-            return res.Success(new NumberNode(tok));
+            return res.Success(new NumberNode((Token<double>)tok));
         }
         else if (tok.Type == TokenType.STRING)
         {
             res.Register(Advance());
-            return res.Success(new StringNode(tok));
+            return res.Success(new StringNode((Token<string>)tok));
         }
 
         // check identifier
@@ -922,7 +922,7 @@ public class Parser
 
         while (currentToken.Type == TokenType.POW)
         {
-            Token opTok = currentToken;
+            Token<TokenNoValueType> opTok = (Token<TokenNoValueType>)currentToken;
             res.Register(Advance());
 
             INode? right = res.Register(Factor());
@@ -939,7 +939,7 @@ public class Parser
     {
         ParseResult res = new();
 
-        Token tok = currentToken;
+        IToken tok = currentToken;
 
         // if there is a plus or a minus it could be +5 or -5
         if (tok.Type is TokenType.PLUS or TokenType.MINUS)
@@ -950,7 +950,7 @@ public class Parser
             {
                 return res;
             }
-            return res.Success(new UnaryOpNode(tok, factor));
+            return res.Success(new UnaryOpNode((Token<TokenNoValueType>)tok, factor));
         }
 
         return Power();
@@ -968,7 +968,7 @@ public class Parser
         // point before line
         while (currentToken.Type is TokenType.MUL or TokenType.DIV)
         {
-            Token opTok = currentToken;
+            Token<TokenNoValueType> opTok = (Token<TokenNoValueType>)currentToken;
 
             res.Register(Advance());
             INode? right = res.Register(Factor());
@@ -993,7 +993,7 @@ public class Parser
 
         while (currentToken.Type is TokenType.PLUS or TokenType.MINUS)
         { // punkt vor strich
-            Token opTok = currentToken;
+            Token<TokenNoValueType> opTok = (Token<TokenNoValueType>)currentToken;
 
             res.Register(Advance());
             INode? right = res.Register(Term());
@@ -1012,7 +1012,7 @@ public class Parser
 
         if (currentToken.Matches(TokenType.KEYWORD, "NOT"))
         {
-            Token opTok = currentToken;
+            IToken opTok = currentToken;
 
             res.Register(Advance());
             INode node = res.Register(CompExpr());
@@ -1033,7 +1033,7 @@ public class Parser
         // This checks for the comparison operators
         while (currentToken.Type is TokenType.EE or TokenType.NE or TokenType.GT or TokenType.LT or TokenType.GTE or TokenType.LTE)
         {
-            Token opTok = currentToken;
+            Token<TokenNoValueType> opTok = (Token<TokenNoValueType>)currentToken;
 
             res.Register(Advance());
             INode? right = res.Register(ArithExpr());
@@ -1069,7 +1069,7 @@ public class Parser
 
         while (currentToken.Matches(TokenType.KEYWORD, "AND") || currentToken.Matches(TokenType.KEYWORD, "OR"))
         {
-            Token opTok = currentToken;
+            IToken opTok = currentToken;
 
             res.Register(Advance());
             INode? right = res.Register(CompExpr());


### PR DESCRIPTION
Rewrote the Token class to take in a generic T instead of using object.
When tested with the perf.ys script the time to run reduced from an average of 4800.25ms to only 358.75ms